### PR TITLE
Drop support for EOLd Ruby 2.5 and 2.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, '3.0', 3.1]
+        ruby: [2.7, '3.0', 3.1]
         gemfile: [5.2, '6.0', 6.1, '7.0']
-        exclude:
-          - ruby: 2.6
-            gemfile: head
-          - ruby: 2.6
-            gemfile: '7.0'
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/actionpack-${{ matrix.gemfile }}.gemfile
     steps:

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_development_dependency 'actionpack', '~> 7.0'
   s.add_development_dependency 'pry', '~> 0'


### PR DESCRIPTION
EOL was 2022-03-31