### PR TITLE
Allow option to preserve the sort order as inputted in the `only` array of countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ country_select("user", "country")
 Supplying priority countries to be placed at the top of the list:
 
 ```ruby
-country_select("user", "country", priority_countries: ["GB", "FR", "DE"])
+country_select("user", "country", priority_countries: ["GB", "FR", "DE"]) # Countries will be sorted by name according to the current locale
+# or
+country_select("user", "country", priority_countries: ["GB", "FR", "DE"], sort_provided: false) # Countries will be displayed is the provided order
 ```
 
 Supplying only certain countries:
 
 ```ruby
-country_select("user", "country", only: ["GB", "FR", "DE"])
+country_select("user", "country", only: ["GB", "FR", "DE"]) # Countries will be sorted by name according to the current locale
+# or
+country_select("user", "country", only: ["GB", "FR", "DE"], sort_provided: false) # Countries will be displayed is the provided order
 ```
 
 Discarding certain countries:

--- a/lib/country_select/defaults.rb
+++ b/lib/country_select/defaults.rb
@@ -5,6 +5,7 @@ module CountrySelect
     locale: nil,
     only: nil,
     priority_countries: nil,
-    priority_countries_divider: "-" * 15
+    priority_countries_divider: "-" * 15,
+    sort_only: true
   }
 end

--- a/lib/country_select/defaults.rb
+++ b/lib/country_select/defaults.rb
@@ -6,6 +6,6 @@ module CountrySelect
     only: nil,
     priority_countries: nil,
     priority_countries_divider: "-" * 15,
-    sort_only: true
+    sort_provided: true
   }
 end

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -59,14 +59,14 @@ module CountrySelect
     end
 
     def country_options
-      country_options_for(all_country_codes, true)
+      country_options_for(all_country_codes, @options.fetch(:sort_only, ::CountrySelect::DEFAULTS[:sort_only]))
     end
 
     def all_country_codes
       codes = ISO3166::Country.codes
 
       if only_country_codes.present?
-        codes & only_country_codes
+        only_country_codes & codes
       elsif except_country_codes.present?
         codes - except_country_codes
       else

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -19,7 +19,7 @@ module CountrySelect
       }
 
       if priority_countries.present?
-        priority_countries_options = country_options_for(priority_countries, false)
+        priority_countries_options = country_options_for(priority_countries, @options.fetch(:sort_provided, ::CountrySelect::DEFAULTS[:sort_provided]))
 
         option_tags = options_for_select(priority_countries_options, option_tags_options)
         option_tags += html_safe_newline + options_for_select([priority_countries_divider], disabled: priority_countries_divider)
@@ -59,7 +59,7 @@ module CountrySelect
     end
 
     def country_options
-      country_options_for(all_country_codes, @options.fetch(:sort_only, ::CountrySelect::DEFAULTS[:sort_only]))
+      country_options_for(all_country_codes, @options.fetch(:sort_provided, ::CountrySelect::DEFAULTS[:sort_provided]))
     end
 
     def all_country_codes

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -92,6 +92,40 @@ describe "CountrySelect" do
   it "accepts priority countries" do
     tag = options_for_select(
       [
+        ['Denmark', 'DK'],
+        ['Latvia','LV'],
+        ['United States','US'],
+        ['-'*15,'-'*15]
+      ],
+      selected: 'US',
+      disabled: '-'*15
+    )
+
+    walrus.country_code = 'US'
+    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'])
+    expect(t).to include(tag)
+  end
+
+  it "priority countries are sorted by name by default" do
+    tag = options_for_select(
+      [
+        ['Denmark', 'DK'],
+        ['Latvia','LV'],
+        ['United States','US'],
+        ['-'*15,'-'*15]
+      ],
+      selected: 'US',
+      disabled: '-'*15
+    )
+
+    walrus.country_code = 'US'
+    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'])
+    expect(t).to include(tag)
+  end
+
+  it "priority countries with `sort_provided: false` preserves the provided order" do
+    tag = options_for_select(
+      [
         ['Latvia','LV'],
         ['United States','US'],
         ['Denmark', 'DK'],
@@ -102,7 +136,7 @@ describe "CountrySelect" do
     )
 
     walrus.country_code = 'US'
-    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'])
+    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'], sort_provided: false)
     expect(t).to include(tag)
   end
 
@@ -139,6 +173,18 @@ describe "CountrySelect" do
     expect(t).to_not include(tag)
   end
 
+  it "countries provided in `only` are sorted by name by default" do
+    t = builder.country_select(:country_code, only: ['PT','DE','AR'])
+    order = t.scan(/value="(\w{2})"/).map { |o| o[0] }
+    expect(order).to eq(['AR', 'DE', 'PT'])
+  end
+
+  it "countries provided in `only` with `sort_provided` to false keeps the order of the provided countries" do
+    t = builder.country_select(:country_code, only: ['PT','DE','AR'], sort_provided: false)
+    order = t.scan(/value="(\w{2})"/).map { |o| o[0] }
+    expect(order).to eq(['PT','DE','AR'])
+  end
+
   context "when there is a default 'except' configured" do
     around do |example|
       old_value = ::CountrySelect::DEFAULTS[:except]
@@ -160,9 +206,9 @@ describe "CountrySelect" do
     it "accepts priority countries" do
       tag = options_for_select(
         [
+          ['Denmark', 'DK'],
           ['Latvia','LV'],
           ['United States','US'],
-          ['Denmark', 'DK'],
           ['-'*15,'-'*15]
         ],
         selected: 'US',


### PR DESCRIPTION
@scudco 

I've been thinking about #194 , and came up with another possibility:

```ruby
country_select :user, :country_code, only: %w(CH AT DE), sort_provided: false

country_select :user, :country_code, priority_countries: %w(CH AT DE), sort_provided: false
```

That is, adding a `sort_provided` option that controls if the list of countries is locale-sorted or we use the order of the `only` and `priority_countries` array. 

~The default behaviour is unchanged from the current version, this just adds the new option to allow preserving the sort order as inputted, and is a pretty small code change.~

This adds the new option and is a small change, but it changes the default behaviour for `priority_countries` to sorting the list, so that both `priority_countries` and `only` have the same sorting behaviour and defaults, so it does include a breaking change.