### PR TITLE
Add deprecation warning for old priority country syntax

### DIFF
--- a/lib/country_select/country_select_helper.rb
+++ b/lib/country_select/country_select_helper.rb
@@ -6,6 +6,11 @@ module ActionView
           html_options = options
           options = priority_or_options
         else
+          if RUBY_VERSION =~ /^3\.\d\.\d/
+            warn "DEPRECATION WARNING: Setting priority countries with the 1.x syntax is deprecated. Please use the `priority_countries:` option.", uplevel: 1, category: :deprecated
+          else
+            warn "DEPRECATION WARNING: Setting priority countries with the 1.x syntax is deprecated. Please use the `priority_countries:` option.", uplevel: 1
+          end
           options[:priority_countries] = priority_or_options
         end
 


### PR DESCRIPTION
The syntax change for defining priority countries happened on 2.0, released on 2014-08-10, so I think we should deprecate it.