### PR TITLE
[Experiment] Remove sort_alphabetical dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     country_select (7.0.0)
       countries (~> 5.0)
-      sort_alphabetical (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -74,11 +73,8 @@ GEM
     rspec-support (3.11.0)
     simple_po_parser (1.1.6)
     sixarm_ruby_unaccent (1.2.0)
-    sort_alphabetical (1.1.0)
-      unicode_utils (>= 1.2.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicode_utils (1.4.0)
 
 PLATFORMS
   x86_64-darwin-21
@@ -91,4 +87,4 @@ DEPENDENCIES
   rspec (~> 3)
 
 BUNDLED WITH
-   2.3.10
+   2.3.11

--- a/country_select.gemspec
+++ b/country_select.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
 
   s.add_dependency 'countries', '~> 5.0'
-  s.add_dependency 'sort_alphabetical', '~> 1.1'
 end

--- a/lib/country_select.rb
+++ b/lib/country_select.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'countries'
-require 'sort_alphabetical'
 
 require 'country_select/version'
 require 'country_select/defaults'

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -99,11 +99,7 @@ module CountrySelect
         end
 
         if sorted
-          if country_list.respond_to?(:sort_alphabetical)
-            country_list.sort_alphabetical
-          else
-            country_list.sort
-          end
+          country_list.sort_by { |name, code| [I18n.transliterate(name), name] }
         else
           country_list
         end

--- a/lib/country_select_without_sort_alphabetical.rb
+++ b/lib/country_select_without_sort_alphabetical.rb
@@ -1,9 +1,0 @@
-# encoding: utf-8
-
-require 'countries'
-
-require 'country_select/version'
-require 'country_select/defaults'
-require 'country_select/formats'
-require 'country_select/tag_helper'
-require 'country_select/country_select_helper'

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -235,23 +235,6 @@ describe "CountrySelect" do
     expect(order).to eq(['AF', 'AX', 'AL', 'ZW'])
   end
 
-  context "without sort_alphabetical" do
-    before do
-      Enumerable.send(:alias_method, :_sort_alphabetical, :sort_alphabetical)
-      Enumerable.send(:remove_method, :sort_alphabetical)
-    end
-
-    after do
-      Enumerable.send(:alias_method, :sort_alphabetical, :_sort_alphabetical)
-    end
-
-    it 'falls back to regular sort' do
-      tag = builder.country_select(:country_code, only: ['AX', 'AL', 'AF', 'ZW'])
-      order = tag.scan(/value="(\w{2})"/).map { |o| o[0] }
-      expect(order).to eq(['AF', 'AL', 'ZW', 'AX'])
-    end
-  end
-
   describe "custom formats" do
     it "accepts a custom formatter" do
       ::CountrySelect::FORMATS[:with_alpha2] = lambda do |country|


### PR DESCRIPTION
Try removing sort_alphabetical and replacing with using `I18n.transliterate` for unicode sorting.

`sort_alphabetical` gem hasn't been updated in 6 years, and depends on `unicode_utils` that hasn't been updated in almost 10 years.

Using `I18n.transliterate` seems to work, but this will need some additional tests