### PR TITLE
Don't sort priority countries

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -19,7 +19,7 @@ module CountrySelect
       }
 
       if priority_countries.present?
-        priority_countries_options = country_options_for(priority_countries, @options.fetch(:sort_provided, ::CountrySelect::DEFAULTS[:sort_provided]))
+        priority_countries_options = country_options_for(priority_countries, false)
 
         option_tags = options_for_select(priority_countries_options, option_tags_options)
         option_tags += html_safe_newline + options_for_select([priority_countries_divider], disabled: priority_countries_divider)

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -102,7 +102,7 @@ describe "CountrySelect" do
     )
 
     walrus.country_code = 'US'
-    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'])
+    t = builder.country_select(:country_code, priority_countries: ['DK','LV','US'])
     expect(t).to include(tag)
   end
 
@@ -119,7 +119,7 @@ describe "CountrySelect" do
     )
 
     walrus.country_code = 'US'
-    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'])
+    t = builder.country_select(:country_code, priority_countries: ['DK','LV','US'])
     expect(t).to include(tag)
   end
 
@@ -216,7 +216,7 @@ describe "CountrySelect" do
       )
 
       walrus.country_code = 'US'
-      t = builder.country_select(:country_code, ['LV','US','DK'])
+      t = builder.country_select(:country_code, ['DK','LV','US'])
       expect(t).to include(tag)
     end
 


### PR DESCRIPTION
According to https://github.com/countries/country_select/issues/52 we shouldn't sort priority countries.

A change has been introduced in https://github.com/countries/country_select/pull/202 to use the `sort_provided` value instead of `false`.

It removes the possibility to have the normal list of countries sorted alphabetically, and the priority list sorted as provided (which imo is an intuitive expectation).

We should either use a different attribute (`sort_priority_provided`) or just set it to `false` as it used to be.