### PR TITLE
Fix priority country sorting bug

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -59,19 +59,18 @@ module CountrySelect
     end
 
     def country_options
-      country_options_for(all_country_codes, @options.fetch(:sort_provided, ::CountrySelect::DEFAULTS[:sort_provided]))
-    end
-
-    def all_country_codes
-      codes = ISO3166::Country.codes
-
       if only_country_codes.present?
-        only_country_codes & codes
+        codes = only_country_codes & ISO3166::Country.codes
+        sort = @options.fetch(:sort_provided, ::CountrySelect::DEFAULTS[:sort_provided])
       elsif except_country_codes.present?
-        codes - except_country_codes
+        codes = ISO3166::Country.codes - except_country_codes
+        sort = true
       else
-        codes
+        codes = ISO3166::Country.codes
+        sort = true
       end
+
+      country_options_for(codes, sort)
     end
 
     def country_options_for(country_codes, sorted=true)

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -140,6 +140,24 @@ describe "CountrySelect" do
     expect(t).to include(tag)
   end
 
+  it "priority countries with `sort_provided: false` still sorts the non-priority countries by name" do
+    tag = options_for_select(
+      [
+        ['Latvia','LV'],
+        ['United States','US'],
+        ['Denmark', 'DK'],
+        ['-'*15,'-'*15],
+        ['Afghanistan','AF']
+      ],
+      selected: 'AF',
+      disabled: '-'*15
+    )
+
+    walrus.country_code = 'AF'
+    t = builder.country_select(:country_code, priority_countries: ['LV','US','DK'], sort_provided: false)
+    expect(t).to include(tag)
+  end
+
   describe "when selected options is not an array" do
     it "selects only the first matching option" do
       tag = options_for_select([["United States", "US"],["Uruguay", "UY"]], "US")


### PR DESCRIPTION
Fix: Using priority countries with the sort_provided: false, should still sort the rest of the countries by name.

See issue described in #209