### PR TITLE
Adding support for Rails 7.1 after recent Form Options helper changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
-      
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [2.7, '3.0', 3.1, 3.2]
-        gemfile: [5.2, '6.0', 6.1, '7.0']
+        gemfile: [5.2, '6.0', 6.1, '7.0', 7.1]
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/actionpack-${{ matrix.gemfile }}.gemfile
       CC_TEST_REPORTER_ID: 0d09e6611c01dedd75511b1c60f62329d01729289e06375cfe67cefe67013d9f
@@ -29,7 +29,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run tests
-    
+
       run: bundle exec rake
     - name: Publish code coverage
       uses: paambaati/codeclimate-action@v4.0.0

--- a/gemfiles/actionpack-7.1.gemfile
+++ b/gemfiles/actionpack-7.1.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'railties', '~> 7.1.0.alpha', github: 'rails/rails'
+gem 'actionpack', '~> 7.1.0.alpha', github: 'rails/rails'
+gem 'nokogiri', '~> 1.14'

--- a/gemfiles/actionpack-7.1.gemfile.lock
+++ b/gemfiles/actionpack-7.1.gemfile.lock
@@ -1,0 +1,133 @@
+GIT
+  remote: https://github.com/rails/rails.git
+  revision: 5b2523edaa131eec7b18780b7916760828262df4
+  specs:
+    actionpack (7.1.0.alpha)
+      actionview (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.6)
+    actionview (7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.6)
+    activesupport (7.1.0.alpha)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    railties (7.1.0.alpha)
+      actionpack (= 7.1.0.alpha)
+      activesupport (= 7.1.0.alpha)
+      irb
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+
+PATH
+  remote: ..
+  specs:
+    country_select (8.0.1)
+      countries (~> 5.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.4)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    countries (5.5.0)
+      unaccent (~> 0.3)
+    crass (1.0.6)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    erubi (1.12.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.7.0)
+      reline (>= 0.3.0)
+    loofah (2.21.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    method_source (1.0.0)
+    minitest (5.18.1)
+    nokogiri (1.15.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.7.1)
+    rack (3.0.8)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    rake (13.0.6)
+    reline (0.3.5)
+      io-console (~> 0.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    thor (1.2.2)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
+    webrick (1.8.1)
+    zeitwerk (2.6.8)
+
+PLATFORMS
+  arm64-darwin-22
+  x86_64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  actionpack (~> 7.1.0.alpha)!
+  country_select!
+  nokogiri (~> 1.14)
+  pry (~> 0)
+  railties (~> 7.1.0.alpha)!
+  rake (~> 13)
+  rspec (~> 3)
+  simplecov (~> 0.22)
+
+BUNDLED WITH
+   2.4.2

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -4,6 +4,11 @@ module CountrySelect
   class CountryNotFoundError < StandardError; end
 
   module TagHelper
+    unless respond_to?(:options_for_select)
+      include ActionView::Helpers::FormOptionsHelper
+      include ActionView::Helpers::Tags::SelectRenderer if defined?(ActionView::Helpers::Tags::SelectRenderer)
+    end
+
     def country_option_tags
       # In Rails 5.2+, `value` accepts no arguments and must also be called
       # with parens to avoid the local variable of the same name


### PR DESCRIPTION
A recent Rails Edge commit (https://github.com/rails/rails/commit/77f3fc118a211c973bc3ca0b720dcba932474f89) moves the Form Options helper into select rendering classes. This is a breaking change for `country_select`. 

This PR adds support for the changes, and it has been tested with all of the versions of Rails that `country_select` supports.

If the approach I've used is not what you prefer, perhaps it will spark some additional ideas for addressing the issue.
