### PR TITLE
Use the new modules created on Rails 7.1

### DIFF
--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -4,6 +4,11 @@ module CountrySelect
   class CountryNotFoundError < StandardError; end
 
   module TagHelper
+    if Rails.version.to_f >= 7.1
+      include ::ActionView::Helpers::Tags::SelectRenderer
+      include ::ActionView::Helpers::FormOptionsHelper
+    end
+
     def country_option_tags
       # In Rails 5.2+, `value` accepts no arguments and must also be called
       # with parens to avoid the local variable of the same name


### PR DESCRIPTION
Rails 7.1 extracted some methods to 2 new modules: https://github.com/rails/rails/commit/77f3fc118a211c973bc3ca0b720dcba932474f89 https://github.com/rails/rails/commit/9e85c2cd0543fb268a8efe47c34330b77d813b78

These new commits makes country_select breaks with ActionView::Template::Error: undefined method `options_for_select' for #<ActionView::Helpers::Tags::CountrySelect