### PR TITLE
Use <hr> as divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,6 @@ Pre-selecting a particular country:
 country_select("user", "country", selected: "GB")
 ```
 
-Changing the divider when priority_countries is active.
-```ruby
-country_select("user", "country", priority_countries: ["AR", "US"], priority_countries_divider: "~~~~~~")
-```
-
 Using existing `select` options:
 ```ruby
 country_select("user", "country", include_blank: true)
@@ -126,7 +121,7 @@ country_select("user", "country", format: :with_data_attrs)
 ### Using customized defaults
 
 You can configure overridable defaults for `except`, `format`, `locale`,
-`only`, `priority_countries` and `priority_countries_divider` in an initializer.
+`only` and `priority_countries` in an initializer.
 
 ````ruby
 # config/initializers/country_select.rb

--- a/lib/country_select/defaults.rb
+++ b/lib/country_select/defaults.rb
@@ -7,7 +7,6 @@ module CountrySelect
     locale: nil,
     only: nil,
     priority_countries: nil,
-    priority_countries_divider: '-' * 15,
     sort_provided: true
   }
 end

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -43,10 +43,6 @@ module CountrySelect
       @options.fetch(:priority_countries, ::CountrySelect::DEFAULTS[:priority_countries])
     end
 
-    def priority_countries_divider
-      @options.fetch(:priority_countries_divider, ::CountrySelect::DEFAULTS[:priority_countries_divider])
-    end
-
     def only_country_codes
       @options.fetch(:only, ::CountrySelect::DEFAULTS[:only])
     end
@@ -98,9 +94,7 @@ module CountrySelect
     end
 
     def priority_options_for_select(priority_countries_options, tags_options)
-      option_tags = options_for_select(priority_countries_options, tags_options)
-      option_tags += "\n".html_safe +
-                     options_for_select([priority_countries_divider], disabled: priority_countries_divider)
+      options_for_select(priority_countries_options, tags_options) + "\n<hr>".html_safe
     end
 
     def get_formatted_country(code_or_name)

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -95,12 +95,10 @@ describe 'CountrySelect' do
       [
         ['Denmark', 'DK'],
         ['Latvia', 'LV'],
-        ['United States', 'US'],
-        ['-' * 15, '-' * 15]
+        ['United States', 'US']
       ],
-      selected: 'US',
-      disabled: '-' * 15
-    )
+      selected: 'US'
+    ) + "\n<hr>".html_safe
 
     walrus.country_code = 'US'
     t = builder.country_select(:country_code, priority_countries: %w[LV US DK])
@@ -112,12 +110,10 @@ describe 'CountrySelect' do
       [
         ['Denmark', 'DK'],
         ['Latvia', 'LV'],
-        ['United States', 'US'],
-        ['-' * 15, '-' * 15]
+        ['United States', 'US']
       ],
-      selected: 'US',
-      disabled: '-' * 15
-    )
+      selected: 'US'
+    ) + "\n<hr>".html_safe
 
     walrus.country_code = 'US'
     t = builder.country_select(:country_code, priority_countries: %w[LV US DK])
@@ -129,12 +125,10 @@ describe 'CountrySelect' do
       [
         ['Latvia', 'LV'],
         ['United States', 'US'],
-        ['Denmark', 'DK'],
-        ['-' * 15, '-' * 15]
+        ['Denmark', 'DK']
       ],
       selected: 'US',
-      disabled: '-' * 15
-    )
+    ) + "\n<hr>".html_safe
 
     walrus.country_code = 'US'
     t = builder.country_select(:country_code, priority_countries: %w[LV US DK], sort_provided: false)
@@ -146,12 +140,13 @@ describe 'CountrySelect' do
       [
         ['Latvia', 'LV'],
         ['United States', 'US'],
-        ['Denmark', 'DK'],
-        ['-' * 15, '-' * 15],
+        ['Denmark', 'DK']
+      ]
+    ) + "\n<hr>\n".html_safe + options_for_select(
+      [
         ['Afghanistan', 'AF']
       ],
-      selected: 'AF',
-      disabled: '-' * 15
+      selected: 'AF'
     )
 
     walrus.country_code = 'AF'


### PR DESCRIPTION
In the WHATWG HTML specification, a delimiter can be represented by including hr in the select element. I believe that this is preferable to the pseudo-delimiters of hyphens.

https://github.com/whatwg/html/pull/9124
