### PR TITLE
fix: Improve sorting for non-Latin country names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    country_select (10.0.0)
+    country_select (10.0.1)
       countries (> 5.0, < 8.0)
 
 GEM

--- a/lib/country_select/tag_helper.rb
+++ b/lib/country_select/tag_helper.rb
@@ -77,7 +77,14 @@ module CountrySelect
       I18n.with_locale(locale) do
         country_list = country_codes.map { |code_or_name| get_formatted_country(code_or_name) }
 
-        country_list.sort_by! { |name, _| [I18n.transliterate(name.to_s), name] } if sorted
+        country_list.sort_by! { |name, _|
+          transliterated_name = I18n.transliterate(name.to_s)
+          if transliterated_name.include?('?') # For languages that cannot be transliterated (e.g. languages with non-Latin scripts)
+            [name, name] # If transliteration fails, duplicate the original name to maintain a consistent two-element array structure.
+          else
+            [transliterated_name, name]
+          end
+        } if sorted
         country_list
       end
     end

--- a/spec/country_select_spec.rb
+++ b/spec/country_select_spec.rb
@@ -238,6 +238,16 @@ describe 'CountrySelect' do
     expect(order).to eq(%w[AF AX AL ZW])
   end
 
+  it 'sorts non-Latin strings' do
+    I18n.available_locales = [:ja]
+    I18n.locale = :ja
+    ISO3166.reset
+
+    tag = builder.country_select(:country_code, only: %w[US CN JP KR])
+    order = tag.scan(/value="(\w{2})"/).map { |o| o[0] }
+    expect(order).to eq(%w[CN KR JP US])
+  end
+
   describe 'custom formats' do
     it 'accepts a custom formatter' do
       CountrySelect::FORMATS[:with_alpha2] = lambda do |country|


### PR DESCRIPTION
Thank you so much for creating and maintaining this wonderful library.

I recently encountered an issue when using it with the locale set to `ja`, where country names weren’t sorting as expected.

After some investigation, I discovered that the sorting logic uses `I18n.transliterate`, which—as noted in the [documentation](https://www.rubydoc.info/gems/activesupport/2.3.17/I18n.transliterate)—converts non-Latin characters into a `'?'`. This means that Japanese country names are turned into a series of question marks (e.g., `"???"`), which disrupts the sort order.

To address this, I’ve updated the code so that if the transliteration result contains a `'?'`, the original string is used instead for sorting. Since country names in Latin script normally wouldn’t include a `'?'`, this approach reliably detects non-Latin characters without requiring locale-specific handling.

I appreciate your time in reviewing this change and hope it improves the internationalization support of the library.